### PR TITLE
feat: queue animations

### DIFF
--- a/app/TodoAddForm.tsx
+++ b/app/TodoAddForm.tsx
@@ -1,8 +1,10 @@
-import { useContext, type FormEvent } from "react"
+import { useContext, useState, type FormEvent } from "react"
+import { FlipWrapper } from "../src/Flip.js"
 import { TodoContext } from "./TodoApp.js"
 
 export function TodoAddForm() {
   const dispatch = useContext(TodoContext)
+  const [isBig, setIsBig] = useState(false)
 
   function handleSubmit(ev: FormEvent<HTMLFormElement>) {
     ev.preventDefault()
@@ -20,9 +22,22 @@ export function TodoAddForm() {
   }
 
   return (
-    <form className="flex-x" onSubmit={handleSubmit}>
-      <input type="text" name="title" required className="flex-1" />
-      <button type="submit">Add</button>
+    <form className="flex-x relative" onSubmit={handleSubmit}>
+      <FlipWrapper>
+        <button type="button" onClick={() => setIsBig((v) => !v)}>
+          Resize
+        </button>
+      </FlipWrapper>
+      <FlipWrapper>
+        {isBig ? (
+          <textarea name="title" rows={3} required className="flex-1" />
+        ) : (
+          <input type="text" name="title" required className="flex-1" />
+        )}
+      </FlipWrapper>
+      <FlipWrapper>
+        <button type="submit">Add</button>
+      </FlipWrapper>
     </form>
   )
 }

--- a/app/TodoList.tsx
+++ b/app/TodoList.tsx
@@ -6,7 +6,7 @@ export function TodoList(props: { todos: Todo[]; showDone: boolean }) {
   const { todos, showDone } = props
 
   return (
-    <div className="grid">
+    <div className="grid relative">
       <FlipList>
         {todos
           .filter((todo) => showDone || !todo.done)

--- a/app/index.css
+++ b/app/index.css
@@ -56,6 +56,11 @@ body {
   max-width: 50rem;
 }
 
+.relative {
+  position: relative;
+}
+
+textarea,
 input[type="text"] {
   background: none;
   padding: 8px;

--- a/src/Flip.tsx
+++ b/src/Flip.tsx
@@ -17,48 +17,50 @@ import { defaultSpring } from "./createSpring.js"
  */
 export interface FlipOptions {
   /**
-   * CSS Animation timing options. Passed directly to {@link onMove}.
+   * CSS Animation timing options. Passed directly to animation callbacks.
    *
    * Default: {@link defaultSpring}.
    */
-  timing?: EffectTiming
+  timing?: EffectTiming | undefined
 
   /**
-   * Callback function which animates the element when it moves.
+   * Callback function which animates an element when it moves.
    *
-   * Default: {@link animateMove}.
-   * You can override it to change the animation behavior.
+   * This is called whenever an element's computed position or size changed since previous render.
+   *
+   * Default: {@link animateFrom}.
+   *
+   * Pass `null` to disable move animations.
+   *
+   * The returned promise will be used to delay subsequent animations.
    */
-  onMove?: (elem: Element, transform: Keyframe, timing: EffectTiming) => Promise<void>
+  onMove?:
+    | ((elem: Element, transform: Keyframe, timing: EffectTiming) => Promise<void>)
+    | null
+    | undefined
 
   /**
    * Function used to compute element's position and size.
    *
-   * Called on every rerender.
-   * If the values returned by this function change, the element will be animated.
-   *
-   * Only the difference between old and new value is used for the animation.
+   * Only the difference between returned values is used for the animation.
    * The absolute returned position doesn't matter.
-   *
-   * You can override it to change the parent to animate relative to.
    *
    * Default: {@link getElementOffset}.
    */
-  getElementRect?: (elem: HTMLElement) => DOMRect
+  getElementRect?: ((elem: HTMLElement) => DOMRect) | undefined
 }
 
 /**
- * Animates an element whenever its position in the document changes between rerenders.
+ * Calls provided callback whenever element's position changes between rerenders.
  *
- * On every rerender, reads element's position and size and compare it to values from previous render.
+ * On every rerender, reads element's position and size and compare it to the previous value.
  * If values are different, calls the provided callback with the calculated transform.
  *
- * By default, the element position is calculated relative to {@link HTMLElement.offsetParent}.
- * You can control the parent to animate relative to with `position: relative`.
+ * Additionally, recomputes the last position when the element's offsetParent resizes.
  */
 export function useFlip(ref: RefObject<HTMLElement | null>, options: FlipOptions): void {
   const {
-    onMove = animateMove,
+    onMove = animateFrom,
     timing = defaultSpring,
     getElementRect = getElementOffset,
   } = options
@@ -67,7 +69,7 @@ export function useFlip(ref: RefObject<HTMLElement | null>, options: FlipOptions
   useEffect(() => {
     const elem = ref.current
     if (elem == null) return
-    const parent = elem.offsetParent 
+    const parent = elem.offsetParent
     if (parent == null) return
     // Watch for parent resizes.
     let timeout: ReturnType<typeof setTimeout> | undefined
@@ -89,7 +91,7 @@ export function useFlip(ref: RefObject<HTMLElement | null>, options: FlipOptions
       if (rect.current) {
         const style = getDeltaTransform(newRect, rect.current)
         if (style) {
-          onMove(ref.current, style, timing)
+          onMove?.(ref.current, style, timing)
         }
       }
       rect.current = newRect
@@ -144,20 +146,24 @@ export function FlipWrapper(props: FlipWrapperProps): JSX.Element {
  * Animates given element from a given keyframe.
  *
  * Doesn't do anything in prefers-reduced-motion mode.
+ *
+ * Resolves when the animation is finished.
  */
-export async function animateMove(
+export async function animateFrom(
   elem: Element,
-  fromKeyframe: Keyframe,
+  keyframe: Keyframe,
   timing: EffectTiming,
 ): Promise<void> {
   if (!window.matchMedia("(prefers-reduced-motion: reduce)").matches) {
-    const animation = elem.animate([fromKeyframe, {}], timing)
-    await animation.finished
+    await elem.animate([keyframe, {}], timing).finished
   }
 }
 
 /**
  * Returns element's {@link HTMLElement.offsetLeft}, {@link HTMLElement.offsetWidth}, etc. as a {@link DOMRect}.
+ *
+ * Returned positions are relative to {@link HTMLElement.offsetParent}.
+ * This means you can control the parent to animate relative to with `position: relative`.
  */
 export function getElementOffset(elem: HTMLElement): DOMRect {
   return new DOMRect(elem.offsetLeft, elem.offsetTop, elem.offsetWidth, elem.offsetHeight)

--- a/src/createSpring.tsx
+++ b/src/createSpring.tsx
@@ -10,7 +10,7 @@ export interface SpringOptions {
    *
    * @default 0.5kg
    */
-  mass?: number
+  mass?: number | undefined
   /**
    * Physical damping coefficient in kg/s.
    * Damping is a measure of resistance to motion.
@@ -20,7 +20,7 @@ export interface SpringOptions {
    *
    * @default 24kg/s
    */
-  damping?: number
+  damping?: number | undefined
   /**
    * Physical spring stiffness in N/m.
    * Stiffness is the spring constant, which represents the force needed to compress or extend a spring by a unit length.
@@ -30,19 +30,19 @@ export interface SpringOptions {
    *
    * @default 300N/m
    */
-  stiffness?: number
+  stiffness?: number | undefined
   /**
    * Initial velocity in m/s.
    *
    * @default 0m/s
    */
-  velocity?: number
+  velocity?: number | undefined
   /**
    * Number of samples per second to calculate.
    *
    * @default 30
    */
-  resolution?: number
+  resolution?: number | undefined
 }
 
 /**
@@ -56,11 +56,15 @@ export interface SpringOptions {
  */
 export function createSpring(options: SpringOptions = {}): EffectTiming {
   const { mass = 0.5, damping = 24, stiffness = 300, velocity = 0, resolution = 30 } = options
+  if (mass <= 0) throw new Error("Spring mass must be greater than 0")
+  if (stiffness <= 0) throw new Error("Spring stiffness must be greater than 0")
+  if (damping < 0) throw new Error("Spring damping must be greater than or equal to 0")
+  if (resolution <= 0) throw new Error("Spring resolution must be greater than 0")
   const w0 = Math.sqrt(stiffness / mass)
   const zeta = damping / (2 * Math.sqrt(stiffness * mass))
   const wd = zeta < 1 ? w0 * Math.sqrt(1 - zeta ** 2) : 0
   const b = zeta < 1 ? (zeta * w0 + -velocity) / wd : -velocity + w0
-  const duration = zeta < 1 ? 8 / zeta / w0 : 8 / w0
+  const duration = Math.min(zeta < 1 ? 8 / zeta / w0 : 8 / w0, 10) // max 10s
   const samples = Array.from({ length: resolution * duration }).map((_, i) => {
     const t = i / resolution
     const y =


### PR DESCRIPTION
1. Children updates are always debounced until curent animations finish. This means that signal argument is no longer needed, because animations are never interrupted.
2. When items are added and removed in an update – first animate exiting children and then replace old children with new ones.